### PR TITLE
fixed staying invisible after going in and out of "pigeon-mode" with the vampire role

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_cloak/shared.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_cloak/shared.lua
@@ -109,6 +109,14 @@ function SWEP:OnDrop() -- Hopefully this'll work
     self:Remove()
 end
 
+function SWEP:OnRemove() -- hopefully this works for Player.StripWeapons
+    if self.conceal then
+        self:UnCloak()
+    end
+    
+    self:Remove()
+end
+
 function SWEP:ShouldDropOnDie()
     return false
 end

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_cloak/shared.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_cloak/shared.lua
@@ -108,15 +108,15 @@ function SWEP:OnDrop() -- Hopefully this'll work
     
     self:Remove()
 end
---[[
-function SWEP:OnRemove() -- hopefully this works for Player.StripWeapons
+
+function SWEP:OnRemove() -- hopefully this works for Player.StripWeapons (e.g. vampire role)
     if self.conceal then
         self:UnCloak()
     end
     
     -- self:Remove()
 end
---]]
+
 function SWEP:ShouldDropOnDie()
     return false
 end

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_cloak/shared.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_cloak/shared.lua
@@ -108,15 +108,15 @@ function SWEP:OnDrop() -- Hopefully this'll work
     
     self:Remove()
 end
-
+--[[
 function SWEP:OnRemove() -- hopefully this works for Player.StripWeapons
     if self.conceal then
         self:UnCloak()
     end
     
-    self:Remove()
+    -- self:Remove()
 end
-
+--]]
 function SWEP:ShouldDropOnDie()
     return false
 end


### PR DESCRIPTION
"SWEP:OnRemove seems to be triggered by Player.StripWeapons which is used in the Vampire Role when changing to "Pigeon"-Form.
SWEP:OnDrop does NOT trigger in this case."

BUT:
while i tested the fixed and played around i found a (visual) glitch. This glitch visually showed a weapon -- i could only constantly reproduce it with the cloaking device -- but in reality it was the crowbar (at least i think that is what happened).

Reproduction only was consistently in this fixed Version. Reproduction steps:
- cloaking device in hand
- have ONE weapon (slot 2,3)
- go into Pigeon-mode
- instantly go back
-> you now have a bugged cloaking device and are visible, changing weapons back and forth needed to fix

while playing around i somehow got the same glitch with a Mac10 but that one i could not reproduce consistently. It gave me a ServerConsole Output tough: "Bad sequence (8 out of 7 max) in GetSequenceLinearMotion() for model 'weapons/cstrike/c_smg_mac10.mdl'!"